### PR TITLE
fix(layout): 🐛 add SEO tag to post layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,7 +1,6 @@
 ---
 # Custom default layout overriding theme to inject nav
 ---
-{%- seo title=false -%}
 <!DOCTYPE html>
 <html lang="{{ site.lang | default: 'tr' }}">
   <head>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 ---
+{%- seo title=false -%}
 <article class="post">
   <h1>{{ page.title }}</h1>
   <p class="post-meta"><small>{% assign author_name = page.author | default: site.author %}{% assign author_slug = author_name | slugify %}{% if author_name %}<a href="{{ '/authors/' | append: author_slug | append: '/' | relative_url }}">{{ author_name }}</a> • {% endif %}{{ page.date | date: "%Y-%m-%d" }}{% if page.tags %} • {{ page.tags | join: ", " }}{% endif %}</small></p>


### PR DESCRIPTION
* Added `{%- seo title=false -%}` to the post layout to ensure proper SEO handling.
* This change aligns the post layout with the default layout for consistency in SEO practices.